### PR TITLE
Fix running tests on Python 2.7.

### DIFF
--- a/test/test_mutex.py
+++ b/test/test_mutex.py
@@ -24,9 +24,12 @@ class TestDynamoDbMutex(unittest.TestCase):
         super(TestDynamoDbMutex, cls).setUpClass()
 
     def setUp(self):
-        #python 3.6 emits warnings due to requests which can be ignoredz    
-        warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
-
+        #python 3.6 emits warnings due to requests which can be ignoredz
+        try:
+            warnings.filterwarnings("ignore", category=ResourceWarning, message="unclosed.*<ssl.SSLSocket.*>")
+        except NameError:
+            # thrown in python 2.7 as ResourceWarning is not defined
+            pass
     def test_create(self):
         m = DynamoDbMutex(random_name(), "myself", 3 * 1000)
         assert(m.lock())


### PR DESCRIPTION
The tests were failing on Python 2.7 because the call to warnings.filterwarnings was raising an error due to ResourceWarning not being defined. As this error should only happen on Python 2.x where the filter is not needed, it should be ok to just swallow the error.