### PR TITLE
Allow DynamoDB endpoint url to be set using an env variable.

### DIFF
--- a/dyndbmutex/dyndbmutex.py
+++ b/dyndbmutex/dyndbmutex.py
@@ -34,8 +34,9 @@ def timestamp_millis():
 class MutexTable:
 
     def __init__(self, region_name='us-west-2', ttl_minutes=TWO_DAYS_IN_MINUTES):
-        self.dbresource = boto3.resource('dynamodb', region_name=region_name)
-        self.dbclient = boto3.client('dynamodb', region_name=region_name)
+        endpoint_url = os.environ.get("DYNAMO_DB_URL", None)
+        self.dbresource = boto3.resource('dynamodb', region_name=region_name, endpoint_url=endpoint_url)
+        self.dbclient = boto3.client('dynamodb', region_name=region_name, endpoint_url=endpoint_url)
         self.table_name = os.environ.get('DD_MUTEX_TABLE_NAME', DEFAULT_MUTEX_TABLE_NAME)
         logger.info("Mutex table name is " + self.table_name)
         self.ttl_minutes = ttl_minutes
@@ -89,7 +90,7 @@ class MutexTable:
             logger.debug("Called create_table")
             table.wait_until_exists()
             logger.info("Created table " + self.table_name)
-            try: 
+            try:
                 self.dbclient.update_time_to_live(
                 TableName=self.table_name,
                 TimeToLiveSpecification={
@@ -199,7 +200,7 @@ class DynamoDbMutex:
 
     def is_locked(self):
         return self.locked
-    
+
     def get_raw_lock(self):
         return self.table.get_lock(self.lockname)
 


### PR DESCRIPTION
Allow the DynamoDB endpoint url to be set using an environment variable called DYNAMO_DB_URL.

This is useful for local testing or if you need to override the DynamoDB endpoint url for some other reason.

To test locally, follow instructions for downloading and running the local version of DynamoDB: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.DownloadingAndRunning.html

With the local version of DynamoDB running, in the terminal window where you will be running your tests, create an environment variable called DYNAMO_DB_URL and set the value to 'http://localhost:8000'.

Run the tests as you normally would using the command 'python setup.py test'.