### PR TITLE
Demote warning to info in write_lock_item and prune_expired so that lock waits don't generate warnings

### DIFF
--- a/dyndbmutex/dyndbmutex.py
+++ b/dyndbmutex/dyndbmutex.py
@@ -119,7 +119,7 @@ class MutexTable:
             )
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-                logger.warning("Write_item: lockname=" + lockname +
+                logger.info("Write_item: lockname=" + lockname +
                              ", caller=" + caller + ", lock is being held")
                 return False
         logger.debug("Write_item: lockname=" + lockname +
@@ -159,7 +159,7 @@ class MutexTable:
             )
         except botocore.exceptions.ClientError as e:
             if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-                logger.warning("Prune: lockname=" + lockname + ", caller=" + caller +
+                logger.info("Prune: lockname=" + lockname + ", caller=" + caller +
                              " Prune failed")
                 return False
         logger.debug("Prune: lockname=" + lockname + ", caller=" + caller + " Prune succeeded")


### PR DESCRIPTION
Demoting logger.warning() to logger.info() for the conditional check cases in MutexTable.write_lock_item() and MutexTable.prune_expired(). These would be expected events when the mutex is wrapped in a spin lock which waits for the mutex to become available, and logging a warning level event means that log analysis tools are likely to flag these for attention.

The corresponding MutexTable.clear_lock_item() case has been left at warning level since that is called by DynamoDbMutex.release(), and it may be considered an error if the application is trying to release a lock which it doesn't own.