### PR TITLE
DynamoDB TTL is in seconds

### DIFF
--- a/dyndbmutex/dyndbmutex.py
+++ b/dyndbmutex/dyndbmutex.py
@@ -103,7 +103,7 @@ class MutexTable:
 
     def write_lock_item(self, lockname, caller, waitms):
         expire_ts = timestamp_millis() + waitms
-        ttl = expire_ts + self.ttl_minutes*60
+        ttl = expire_ts//1000 + self.ttl_minutes*60
         logger.debug("Write_item: lockname=" + lockname + ", caller=" +
                      caller + ", Expire time is " + str(expire_ts))
         try:

--- a/test/test_mutex.py
+++ b/test/test_mutex.py
@@ -100,7 +100,7 @@ class TestDynamoDbMutex(unittest.TestCase):
         m1 = DynamoDbMutex(name=name, holder=caller, timeoutms=2 * 1000, ttl_minutes=2)
         m1.lock()
         item = m1.get_raw_lock()
-        diff = item['Item']['ttl'] - item['Item']['expire_ts']
+        diff = item['Item']['ttl'] - item['Item']['expire_ts'] // 1000
         print (diff)
         self.assertTrue(diff > 0 and diff <= 2*60)
         DynamoDbMutex.delete_table()


### PR DESCRIPTION
See https://github.com/chiradeep/dyndb-mutex/issues/13 .

This was flagged by a few edge cases, an example is the following scenario:
- lambda function acquires a valid lock
- lambda function is killed externally while lock is being held (reached aws timeout)
- lock remains in place until its TTL
- TTL in dynamodb is set to the year 52984 because milliseconds timestamp is used instead of seconds
- resource remains locked unless lock is manually removed